### PR TITLE
Fix Controller event listener not being Removed

### DIFF
--- a/js/Main.js
+++ b/js/Main.js
@@ -126,6 +126,7 @@ class GameWorld {
       case GAMEOVER_STATE:
         this.audioLoader.stop("finalBattle");
         this.transitionUtilities.gameOver();
+        this.resetGameComponents();
         break;
 
       case CREDITS_STATE:

--- a/js/components/Menu.js
+++ b/js/components/Menu.js
@@ -1,10 +1,11 @@
 class PokeMenu {
-  constructor(viewPort,audioLoader, gameWorldObject) {
+  constructor(viewPort, audioLoader, gameWorldObject) {
     this.viewPort = viewPort;
     this.gameWorldObject = gameWorldObject;
     this.ctx = this.gameWorldObject.ctx;
     this.audioLoader = audioLoader;
     this.options = ["Charizard", "Blastoise", "Venusaur"];
+    this.eventAdded = false;
 
     this.POKEMON_A = 0;
     this.POKEMON_B = 1;
@@ -12,39 +13,48 @@ class PokeMenu {
 
     this.currentHighlightedPokemon = this.POKEMON_A;
 
-    this.controller = (event) =>{
-      if(this.gameWorldObject.currentState == MENU_STATE){
-        if(event.keyCode == 13){
+    this.controller = event => {
+      if (this.gameWorldObject.currentState == MENU_STATE) {
+        if (event.keyCode == 13) {
           this.initiateGame();
         }
         if (event.keyCode === 37) {
-          if(this.currentHighlightedPokemon != 0){
-          this.audioLoader.play("beep");
-          this.currentHighlightedPokemon =  (this.currentHighlightedPokemon - 1) % 3;
+          if (this.currentHighlightedPokemon != 0) {
+            this.audioLoader.play("beep");
+            this.currentHighlightedPokemon =
+              (this.currentHighlightedPokemon - 1) % 3;
           }
         }
         if (event.keyCode === 39) {
           this.audioLoader.play("beep");
-          if(this.currentHighlightedPokemon != 2){
-          this.currentHighlightedPokemon =  (this.currentHighlightedPokemon + 1) % 3;
+          if (this.currentHighlightedPokemon != 2) {
+            this.currentHighlightedPokemon =
+              (this.currentHighlightedPokemon + 1) % 3;
           }
         }
       }
     };
-
-    document.addEventListener("keydown", this.controller);
   }
 
-  initiateGame(){
-     this.gameWorldObject.playerPokemon = this.options[this.currentHighlightedPokemon];
-     this.gameWorldObject.garyPokemon = this.options[(this.currentHighlightedPokemon+1) % 3];
-     this.gameWorldObject.currentState = TILE_WORLD_STATE;
-     this.gameWorldObject.resetGameComponents();
-     
-     document.removeEventListener('keydown',this.controller, true);
+  initiateGame() {
+    this.gameWorldObject.playerPokemon = this.options[
+      this.currentHighlightedPokemon
+    ];
+    this.gameWorldObject.garyPokemon = this.options[
+      (this.currentHighlightedPokemon + 1) % 3
+    ];
+    this.gameWorldObject.currentState = TILE_WORLD_STATE;
+    this.gameWorldObject.resetGameComponents();
+
+    document.removeEventListener("keydown", this.controller, true);
   }
 
   draw() {
+    if (this.gameWorldObject.currentState == MENU_STATE && !this.eventAdded) {
+      document.addEventListener("keydown", this.controller, true);
+      this.eventAdded = true;
+    }
+
     this.drawLogo();
     this.drawChooseText();
 


### PR DESCRIPTION
#Issue
The event listener for the menu controller was not removed even after removing the event listener.

The user selected pokemon still being selected after game end:
For example:
Take Balbasour in one game, loose it with or end the game (but don't refresh browser manually, let game itself reset), then when game comes to pokemon choosing menu again, don't press left or right - press enter directly and choose pokemon. You may notice as first pokemon was Charlizard but still Balbasour was choosen (previous selection).


#FIX
Instead of creating event listener for each new instance of menu object, the event is only added if we are in menu mode, which in turn improves performance as the event listener was not removed it was always listenig for event in menu game.

The second fix was more or less solved by first fix, as event listener still held previous this reference.
Still some hiccups were seen so, on  game over the game is reset to defeult.